### PR TITLE
Add Vitest and sample component test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare"
+    "postinstall": "nuxt prepare",
+    "test": "vitest"
   },
   "dependencies": {
     "@nuxt/fonts": "^0.11.4",
@@ -22,6 +23,10 @@
     "@iconify-json/lucide": "^1.2.53",
     "@nuxtjs/tailwindcss": "^7.0.0-beta.0",
     "@tailwindcss/typography": "^0.5.16",
-    "tailwindcss": "^4.1.11"
+    "tailwindcss": "^4.1.11",
+    "vitest": "^1.5.0",
+    "@vue/test-utils": "^2.4.2",
+    "@vitejs/plugin-vue": "^5.2.4",
+    "jsdom": "^24.0.0"
   }
 }

--- a/tests/components/ApplicationHeader.spec.ts
+++ b/tests/components/ApplicationHeader.spec.ts
@@ -1,0 +1,17 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import ApplicationHeader from '../../components/ApplicationHeader.vue'
+
+const user = { name: 'Jane Doe', status: 'Online' }
+
+describe('ApplicationHeader', () => {
+  it('renders user name', () => {
+    const wrapper = mount(ApplicationHeader, {
+      props: { user },
+      global: {
+        stubs: ['UButton', 'UAvatar']
+      }
+    })
+    expect(wrapper.text()).toContain('Jane Doe')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    environment: 'jsdom'
+  }
+})


### PR DESCRIPTION
## Summary
- add Vitest config and dev dependencies
- create a sample test for `ApplicationHeader`
- add `test` script to package.json

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eea1f9584832c9410df3c6ceb2027